### PR TITLE
Update crosstalk observation api

### DIFF
--- a/experimental/submitnresiglabias.py
+++ b/experimental/submitnresiglabias.py
@@ -44,4 +44,4 @@ request = {
 
 }
 
-common.send_to_lake (request, dosubmit=True)
+common.submit_observation (request, dosubmit=True)

--- a/experimental/submitnresiglabias.py
+++ b/experimental/submitnresiglabias.py
@@ -44,4 +44,7 @@ request = {
 
 }
 
+print ("Need to update this program for direct submission. Quitting.")
+exit(1)
+
 common.submit_observation (request, dosubmit=True)

--- a/lcocommissioning/common/common.py
+++ b/lcocommissioning/common/common.py
@@ -11,7 +11,7 @@ from astropy.coordinates import SkyCoord, Angle
 _log = logging.getLogger(__name__)
 # LCO Request submisison definitions
 VALHALLA_URL = os.getenv('VALHALLA_URL', 'http://internal-observation-portal.lco.gtn')
-VALHALLA_TOKEN = os.getenv('VALHALLA_TOKEN', '')
+VALHALLA_API_TOKEN = os.getenv('VALHALLA_API_TOKEN', '')
 
 # LCO sites
 lco_site_lonlat = {'bpl': (-119.863103, 34.433161),
@@ -112,7 +112,7 @@ def send_request_to_portal (requestgroup, dosubmit=False):
 
     response = requests.post(
         'https://observe.lco.global/api/requestgroups/',
-        headers={'Authorization': 'Token {}'.format(VALHALLA_TOKEN)},
+        headers={'Authorization': 'Token {}'.format(VALHALLA_API_TOKEN)},
         json=requestgroup  # Make sure you use json!
     )
     # Make sure the API call was successful
@@ -133,7 +133,7 @@ def send_to_scheduler(user_request,  dosubmit=False):
     """Submit a user request to LCO Scheduler via Valhalla interface
     """
 
-    auth = 'Token {token}'.format(token=VALHALLA_TOKEN)
+    auth = 'Token {token}'.format(token=VALHALLA_API_TOKEN)
     print(auth)
     url = '{api_root}/api/userrequests/'.format(api_root=VALHALLA_URL)
 
@@ -157,7 +157,7 @@ def send_to_scheduler(user_request,  dosubmit=False):
 def submit_observation(observation, dosubmit=False):
     """ Submit a user request to LCO POND"""
     if dosubmit:
-        headers = {'Authorization': 'Token {token}'.format(token=VALHALLA_TOKEN)}
+        headers = {'Authorization': 'Token {token}'.format(token=VALHALLA_API_TOKEN)}
         response = requests.post(VALHALLA_URL + '/api/schedule/', json=observation, headers=headers)
         try:
             response.raise_for_status()

--- a/lcocommissioning/common/common.py
+++ b/lcocommissioning/common/common.py
@@ -10,9 +10,8 @@ from astropy.coordinates import SkyCoord, Angle
 
 _log = logging.getLogger(__name__)
 # LCO Request submisison definitions
-LAKE_URL = 'http://lake.lco.gtn'
 VALHALLA_URL = os.getenv('VALHALLA_URL', 'http://internal-observation-portal.lco.gtn')
-VALHALLA_API_TOKEN = os.getenv('VALHALLA_API_TOKEN', '')
+VALHALLA_TOKEN = os.getenv('VALHALLA_TOKEN', '')
 
 # LCO sites
 lco_site_lonlat = {'bpl': (-119.863103, 34.433161),
@@ -113,7 +112,7 @@ def send_request_to_portal (requestgroup, dosubmit=False):
 
     response = requests.post(
         'https://observe.lco.global/api/requestgroups/',
-        headers={'Authorization': 'Token {}'.format(VALHALLA_API_TOKEN)},
+        headers={'Authorization': 'Token {}'.format(VALHALLA_TOKEN)},
         json=requestgroup  # Make sure you use json!
     )
     # Make sure the API call was successful
@@ -134,7 +133,7 @@ def send_to_scheduler(user_request,  dosubmit=False):
     """Submit a user request to LCO Scheduler via Valhalla interface
     """
 
-    auth = 'Token {token}'.format(token=VALHALLA_API_TOKEN)
+    auth = 'Token {token}'.format(token=VALHALLA_TOKEN)
     print(auth)
     url = '{api_root}/api/userrequests/'.format(api_root=VALHALLA_URL)
 
@@ -155,18 +154,21 @@ def send_to_scheduler(user_request,  dosubmit=False):
         print('UserRequest that was validated: {}'.format(user_request))
 
 
-def send_to_lake(block, dosubmit=False):
+def submit_observation(observation, dosubmit=False):
     """ Submit a user request to LCO POND"""
     if dosubmit:
-        response = requests.post(LAKE_URL + '/blocks/', json=block)
+        headers = {'Authorization': 'Token {token}'.format(token=VALHALLA_TOKEN)}
+        response = requests.post(VALHALLA_URL + '/api/schedule/', json=observation, headers=headers)
         try:
             response.raise_for_status()
             _log.info(
-                'Submitted block with id: {0}. Check it at {1}/blocks/{0}'.format(response.json()['id'], LAKE_URL))
+                'Submitted observation with id: {0}. Check it at {1}/observations/{0}'.format(
+                    response.json()['id'], VALHALLA_URL
+                )
+            )
         except Exception:
             _log.error(
-                'Failed to submit block: error code {}: {}'.format(response.status_code, response.content))
-
+                'Failed to submit observation: error code {}: {}'.format(response.status_code, response.content))
 
 import matplotlib.pyplot as plt
 import matplotlib.dates as mdates

--- a/lcocommissioning/nres/submit_nres_master_arc.py
+++ b/lcocommissioning/nres/submit_nres_master_arc.py
@@ -1,5 +1,5 @@
 import requests
-from lcocommissioning.common.common import VALHALLA_TOKEN
+from lcocommissioning.common.common import VALHALLA_API_TOKEN
 
 data = {
     'name': 'NRES ThAr Master test',
@@ -49,7 +49,7 @@ data = {
 
 
 url ='http://internal-observation-portal.lco.gtn/api/schedule/'
-headers =  {'Authorization': 'Token {}'.format(VALHALLA_TOKEN)}
+headers =  {'Authorization': 'Token {}'.format(VALHALLA_API_TOKEN)}
 print (headers)
 response = requests.post(url, json=data, headers=headers)
 print (response.content)

--- a/lcocommissioning/nres/submit_nres_master_arc.py
+++ b/lcocommissioning/nres/submit_nres_master_arc.py
@@ -1,5 +1,5 @@
 import requests
-from lcocommissioning.common.common import VALHALLA_API_TOKEN
+from lcocommissioning.common.common import VALHALLA_TOKEN
 
 data = {
     'name': 'NRES ThAr Master test',
@@ -49,7 +49,7 @@ data = {
 
 
 url ='http://internal-observation-portal.lco.gtn/api/schedule/'
-headers =  {'Authorization': 'Token {}'.format(VALHALLA_API_TOKEN)}
+headers =  {'Authorization': 'Token {}'.format(VALHALLA_TOKEN)}
 print (headers)
 response = requests.post(url, json=data, headers=headers)
 print (response.content)

--- a/lcocommissioning/submitFloydsObservation.py
+++ b/lcocommissioning/submitFloydsObservation.py
@@ -203,6 +203,8 @@ def parseCommandLine():
 
 
 def main():
+    print ("Need to update this program for direct submission. Quitting.")
+    exit(1)
     args = parseCommandLine()
     createRequestsForStar(args)
 

--- a/lcocommissioning/submitFloydsObservation.py
+++ b/lcocommissioning/submitFloydsObservation.py
@@ -136,7 +136,7 @@ def createRequestsForStar(context):
     block['molecules'].append(lastflat)
 
     _logger.debug(json.dumps(block, indent=4))
-    common.send_to_lake (block, context.opt_confirmed)
+    common.submit_observation (block, context.opt_confirmed)
 
 
 def parseCommandLine():

--- a/lcocommissioning/submitNameModeTest.py
+++ b/lcocommissioning/submitNameModeTest.py
@@ -94,7 +94,7 @@ def createRequestsForStar(context):
         block['molecules'].append (molecule)
 
         _logger.debug (json.dumps(block,indent=4))
-        common.send_to_lake(block, context.opt_confirmed)
+        common.submit_observation(block, context.opt_confirmed)
 
 
 def parseCommandLine():

--- a/lcocommissioning/submitNameModeTest.py
+++ b/lcocommissioning/submitNameModeTest.py
@@ -158,6 +158,8 @@ def parseCommandLine():
 
 
 def main():
+    print ("Need to update this program for direct submission. Quitting.")
+    exit(1)
     args = parseCommandLine()
     createRequestsForStar(args)
 


### PR DESCRIPTION
Updates to stop using the lakeshim to place observations directly into the schedule. I only updated the crosstalk script that you mentioned, but the other places that you see in the diffed files that use the `submit_observation` function will need to be updated as well if they are still in use.

The `user` command line argument has been removed because it is no longer used. The submitter is determined from the token that gets used.

Since the only thing that changed across configurations was exposure time, I am submitting many instrument configs instead of many configurations to save on some overheads.

I submitted some observations to the dev observation portal, which you can find [here](http://observation-portal-dev.lco.gtn/?order=&state=&name=Sinistro+x+talk&target=&proposal=LCOEngineering&created_after=&created_before=&user=heinrich)